### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Planisphere is a fork/continuation of <https://github.com/yieldbot/vizard>. It k
 <a href="#prerequisites" id="prerequisites"></a>Prerequisites
 -------------------------------------------------------------
 
--   Java 8 with JavaFX
+-   Oracle Java 8 with JavaFX
 
 Usage
 ------


### PR DESCRIPTION
fails with OpenJdk:

NoClassDefFoundError com/sun/image/codec/jpeg/JPEGCodec org.apache.batik.ext.awt.image.codec.jpeg.JPEGImageWriter.writeImage